### PR TITLE
fix/boats-thinks-dts-are-ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@acrontum/boats-utils",
   "version": "2.0.2",
   "description": "Collection of useful boats template helpers.",
-  "main": "dist/src",
   "scripts": {
     "prebuild": "rm -rf dist/*",
     "build": "tsc",
@@ -48,6 +47,6 @@
   "homepage": "https://github.com/acrontum/boats-utils#readme",
   "files": [
     "dist/src/**/*.js",
-    "dist/src/**/*.d.ts"
+    "dist/types/src/**/*.d.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "noImplicitAny": true,
     "declaration": true,
+    "declarationDir": "dist/types",
     "outDir": "./dist",
     "removeComments": true,
     "sourceMap": true,


### PR DESCRIPTION
export typings from another folder, so that passing `-f boats-utils/dist` to boats does not try to load .d.ts files as ts files (then complaining about missing ts-node)